### PR TITLE
Psd Reader Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,3 +335,4 @@ ASALocalRun/
 
 # ionide ignore
 .ionide/
+TestSourceFiles/

--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,10 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# Photoshop file format
+*.psd
+*.psb
+
+# ionide ignore
+.ionide/

--- a/.gitignore
+++ b/.gitignore
@@ -335,4 +335,7 @@ ASALocalRun/
 
 # ionide ignore
 .ionide/
+
+# Other project folders
 TestSourceFiles/
+UX & UI Design/

--- a/ArtArea/ArtArea.Parsing/ArtArea.Parse.csproj
+++ b/ArtArea/ArtArea.Parsing/ArtArea.Parse.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>ArtArea.Parse</AssemblyName>
     <RootNamespace>ArtArea.Parse</RootNamespace>
   </PropertyGroup>

--- a/ArtArea/ArtArea.Parsing/ArtArea.Parse.csproj
+++ b/ArtArea/ArtArea.Parsing/ArtArea.Parse.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AssemblyName>ArtArea.Parse</AssemblyName>
+    <RootNamespace>ArtArea.Parse</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/ArtArea/ArtArea.Parsing/ArtArea.Parsing.csproj
+++ b/ArtArea/ArtArea.Parsing/ArtArea.Parsing.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/ArtArea/ArtArea.Parsing/Program.cs
+++ b/ArtArea/ArtArea.Parsing/Program.cs
@@ -6,7 +6,6 @@ namespace ArtArea.Parse
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
         }
     }
 }

--- a/ArtArea/ArtArea.Parsing/Program.cs
+++ b/ArtArea/ArtArea.Parsing/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace ArtArea.Parsing
+namespace ArtArea.Parse
 {
     class Program
     {

--- a/ArtArea/ArtArea.Parsing/Program.cs
+++ b/ArtArea/ArtArea.Parsing/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ArtArea.Parsing
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/BlendMode.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/BlendMode.cs
@@ -1,0 +1,110 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    /// <summary>
+    /// The mode using which this layer is blended with the layer below it.
+    /// </summary>
+    public enum BlendMode : int
+    {
+        // "pass"
+        PassThrough = 0x70617373,
+
+        // "norm"
+        Normal = 0x6e6f726d,
+
+        // "diss"
+        Dissolve = 0x64697373,
+
+        // "dark"
+        Darken = 0x6461726b,
+
+        // "mul "
+        Multiply = 0x6D756C20,
+
+        // "idiv"
+        ColorBurn = 0x69646976,
+
+        // "lbrn"
+        LinearBurn = 0x6c62726e,
+
+        // "dkCl"
+        DarkerColor = 0x646b436c,
+
+        // "lite"
+        Lighten = 0x6c697465,
+
+        // "scrn"
+        Screen = 0x7363726e,
+
+        // "div "
+        ColorDodge = 0x64697620,
+
+        // "lddg"
+        LinearDodge = 0x6c646467,
+
+        // "lgCl"
+        LighterColor = 0x6c67436c,
+
+        // "over"
+        Overlay = 0x6f766572,
+
+        // "sLit"
+        SoftLight = 0x734c6974,
+
+        // "hLit"
+        HardLight = 0x684c6974,
+
+        // "vLit"
+        VividLight = 0x764c6974,
+
+        // "lLit"
+        LinearLight = 0x6c4c6974,
+
+        // "pLit"
+        PinLight = 0x704c6974,
+
+        // "hMix"
+        HardMix = 0x684d6978,
+
+        // "diff"
+        Difference = 0x64696666,
+
+        // "smud"
+        Exclusion = 0x736d7564,
+
+        // "fsub"
+        Subtract = 0x66737562,
+
+        // "fdiv"
+        Divide = 0x66646976,
+
+        // "hue "
+        Hue = 0x68756520,
+
+        // "sat "
+        Saturation = 0x73617420,
+
+        // "colr"
+        Color = 0x636f6c72,
+
+        // "lum "
+        Luminosity = 0x6c756d20
+
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/BlendMode.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/BlendMode.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     /// <summary>
     /// The mode using which this layer is blended with the layer below it.

--- a/ArtArea/ArtArea.Parsing/Psd/Builder/PSDBuilder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/Builder/PSDBuilder.cs
@@ -1,11 +1,69 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
-using ArtArea.Parse.Psd;
 
 namespace ArtArea.Parse.Psd.Builder
 {
-    public class PSDBuilder
+    public static class PsdBuilder
     {
+        /// <summary>
+        /// Constant signature of .psd file
+        /// </summary>
+        public const string Signature = "8BPS";
+
+        /// <summary>
+        /// Constant signature for layer info
+        /// </summary>
+        public const string AdditionalLayerInfoSignature = "8BIM";
+
+        /// <summary>
+        /// ALternative constant signature for layer info
+        /// </summary>
+        public const string AdditionalLayerInfoSignature_ = "8B64";
+
+        public static PsdFile Read(FileStream stream)
+        {
+            try
+            {
+                var psd = new PsdFile();
+
+                ReadHeader(psd, stream);
+                ReadColorModeData(psd, stream);
+                ReadImageResources(psd, stream);
+                ReadLayerAndMaskInformation(psd, stream);
+                CreateImagedataPlaceholder(psd, stream);
+
+                return psd;
+            }
+            catch(PsdBuildException)
+            {
+                throw;
+            }
+            catch(Exception e)
+            {
+                throw new PsdBuildException("Building .psd file object failed", e);
+            }
+        }
+
+        private static void ReadHeader(PsdFile psd, FileStream stream)
+        {
+        }
+
+        private static void ReadColorModeData(PsdFile psd, FileStream stream)
+        {
+        }
+
+        private static void ReadImageResources(PsdFile psd, FileStream stream)
+        {
+        }
+
+        private static void ReadLayerAndMaskInformation(PsdFile psd, FileStream stream)
+        {
+        }
+
+        private static void CreateImagedataPlaceholder(PsdFile psd, FileStream stream)
+        {
+        }   
     }
 }

--- a/ArtArea/ArtArea.Parsing/Psd/Builder/PSDBuilder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/Builder/PSDBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace ArtArea.Parse.Psd.Builder
@@ -46,8 +47,91 @@ namespace ArtArea.Parse.Psd.Builder
             }
         }
 
+        /// <summary>
+        /// Reades Header part of .psd/.psb file
+        /// </summary>
+        /// <param name="psd">Psd file that should be filled with new header values</param>
+        /// <param name="stream">Stream to read .psd file</param>
         private static void ReadHeader(PsdFile psd, FileStream stream)
         {
+            // read file signature & chack if this file is valid .psd file
+            string signature = stream.ReadUsAsciiString(4);
+
+            if (!string.Equals(signature, Signature, StringComparison.Ordinal)) 
+                throw new PsdBuildException(
+                    $"File signature is not valid. " +
+                    $"File signature \"{signature}\", expected signature \"{Signature}\"");
+
+            // read file version (defines whether it .psd or .psb) & check if it's valid
+            short version = stream.ReadBigEndianInt16();
+
+            if (version < 1 || version > 2)
+                throw new PsdBuildException(
+                    $"File version is not valid. " +
+                    $"File version \"{version}\", expected version 1 or 2");
+
+            psd.Version = version;
+
+            // read 6 reserved bytes & check if all of them are 0
+            byte[] reserved = stream.ReadBytes(6);
+
+            if (reserved.Any(b => b != 0x00))
+                throw new PsdBuildException($"Non-zero bytes in reserved 6 bytes section");
+
+            // read number of channels & check if it is limited correctly
+            short numberOfChannels = stream.ReadBigEndianInt16();
+
+            if (numberOfChannels < PsdFile.MinChannels || numberOfChannels > PsdFile.MaxChannels)
+                throw new PsdBuildException($"Number of channels is out of bounds. " +
+                    $"Number if channels {numberOfChannels} should be in [ {PsdFile.MinChannels}, {PsdFile.MaxChannels} ]");
+
+            psd.NumberOfChannels = numberOfChannels;
+
+            // read file height
+            int height = stream.ReadBigEndianInt32();
+
+            if (height < 1)
+                throw new PsdBuildException($"File height is invalid. File height {height} should be > 0");
+
+            // dependending on version check if file height is not more tham limit
+            if (version == 1 ?
+                height > PsdFile.PsdMaxDimention :
+                height > PsdFile.PsbMaxDemension)
+                throw new PsdBuildException(
+                    $"File height is invalid. " +
+                    $"File height shouldn't be more than {PsdFile.PsdMaxDimention} for .psd and {PsdFile.PsbMaxDemension} for .psb");
+
+            psd.Height = height;
+
+            // read file width
+            int width = stream.ReadBigEndianInt32();
+
+            if (width < 1)
+                throw new PsdBuildException($"File width is invalid. File width {width} should be > 0");
+
+            // dependending on version check if file width is not more tham limit
+            if (version == 1 ?
+                width > PsdFile.PsdMaxDimention :
+                width > PsdFile.PsbMaxDemension)
+                throw new PsdBuildException(
+                    $"File width is invalid. " +
+                    $"File width shouldn't be more than {PsdFile.PsdMaxDimention} for .psd and {PsdFile.PsbMaxDemension} for .psb");
+
+            psd.Width = width;
+
+            // read depth & chekc if it takes valid values
+            short depth = stream.ReadBigEndianInt16();
+            if (depth != 1 && depth != 8 && depth != 16 && depth != 32)
+                throw new PsdBuildException($"File depth is invalid. File depth is {depth} and should be 1, 8, 16, 32");
+
+            psd.Depth = depth;
+
+            // read color mode, check if it's valid & convert to enum
+            short colorMode = stream.ReadBigEndianInt16();
+            if (!Enum.IsDefined(typeof(ColorMode), colorMode))
+                throw new PsdBuildException($"Color mode takes invalid value. Color mode {colorMode}");
+
+            psd.ColorMode = (ColorMode) colorMode;
         }
 
         private static void ReadColorModeData(PsdFile psd, FileStream stream)
@@ -64,6 +148,7 @@ namespace ArtArea.Parse.Psd.Builder
 
         private static void CreateImagedataPlaceholder(PsdFile psd, FileStream stream)
         {
+
         }   
     }
 }

--- a/ArtArea/ArtArea.Parsing/Psd/Builder/PSDBuilder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/Builder/PSDBuilder.cs
@@ -23,7 +23,7 @@ namespace ArtArea.Parse.Psd.Builder
         /// </summary>
         public const string AdditionalLayerInfoSignature_ = "8B64";
 
-        public static PsdFile Read(FileStream stream)
+        public static PsdFile Read(Stream stream)
         {
             try
             {
@@ -52,7 +52,7 @@ namespace ArtArea.Parse.Psd.Builder
         /// </summary>
         /// <param name="psd">Psd file that should be filled with new header values</param>
         /// <param name="stream">Stream to read .psd file</param>
-        private static void ReadHeader(PsdFile psd, FileStream stream)
+        private static void ReadHeader(PsdFile psd, Stream stream)
         {
             // read file signature & chack if this file is valid .psd file
             string signature = stream.ReadUsAsciiString(4);
@@ -134,19 +134,36 @@ namespace ArtArea.Parse.Psd.Builder
             psd.ColorMode = (ColorMode) colorMode;
         }
 
-        private static void ReadColorModeData(PsdFile psd, FileStream stream)
+        /// <summary>
+        /// Reades Color mode data if it's available
+        /// </summary>
+        /// <param name="psd">Psd file that should be filled with color mode data</param>
+        /// <param name="stream">Stream to read .psd file</param>
+        private static void ReadColorModeData(PsdFile psd, Stream stream)
+        {
+            int colorModeDataLength = stream.ReadBigEndianInt32();
+            if (colorModeDataLength < 0)
+                throw new PsdBuildException($"Color Mode Data Length takes invalid value {colorModeDataLength}");
+
+            bool requiresColorModeData = (psd.ColorMode == ColorMode.Indexed || psd.ColorMode == ColorMode.Duotone);
+            bool hasColorModeData = colorModeDataLength > 0;
+
+            if (requiresColorModeData != hasColorModeData)
+                throw new PsdBuildException($"Color mode {psd.ColorMode} requires color mode data, but it's length is 0");
+
+            psd.ColorModeDataLength = colorModeDataLength;
+            psd.ColorModeData = stream.ReadBytes(colorModeDataLength);
+        }
+
+        private static void ReadImageResources(PsdFile psd, Stream stream)
         {
         }
 
-        private static void ReadImageResources(PsdFile psd, FileStream stream)
+        private static void ReadLayerAndMaskInformation(PsdFile psd, Stream stream)
         {
         }
 
-        private static void ReadLayerAndMaskInformation(PsdFile psd, FileStream stream)
-        {
-        }
-
-        private static void CreateImagedataPlaceholder(PsdFile psd, FileStream stream)
+        private static void CreateImagedataPlaceholder(PsdFile psd, Stream stream)
         {
 
         }   

--- a/ArtArea/ArtArea.Parsing/Psd/Builder/PSDBuilder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/Builder/PSDBuilder.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ArtArea.Parse.Psd;
+
+namespace ArtArea.Parse.Psd.Builder
+{
+    public class PSDBuilder
+    {
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/Builder/PsdBuildException.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/Builder/PsdBuildException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace ArtArea.Parse.Psd.Builder
+{
+    /// <summary>
+    /// Thrown if the rules of the PSD/PSB file format have been violated.
+    /// </summary>
+    public class PsdBuildException : Exception
+    {
+        public PsdBuildException()
+            : base()
+        {
+        }
+        
+        public PsdBuildException(string message, Exception innerException = null)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/Builder/StreamUtilities.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/Builder/StreamUtilities.cs
@@ -1,0 +1,428 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace ArtArea.Parse.Psd.Builder
+{
+    /// <summary>
+    /// Utilities pertaining to stream manupulation.
+    /// </summary>
+    internal static class StreamUtililies
+    {
+        /// <summary>
+        /// Reads a specific number of bytes from the stream and returns a newly allocated array containing them.
+        /// </summary>
+        /// <param name="stream">The stream from which to read.</param>
+        /// <param name="byteCount">The number of bytes to read.</param>
+        /// <returns>A newly allocated array containing the bytes read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before <paramref name="byteCount"/> could be read.
+        /// </exception>
+        public static byte[] ReadBytes(this Stream stream, int byteCount)
+        {
+            var ret = new byte[byteCount];
+            stream.ReadBytes(ret);
+            return ret;
+        }
+
+        /// <summary>
+        /// Reads a specific number of bytes from the stream and fills the given array slice with them.
+        /// </summary>
+        /// <param name="stream">The stream from which to read.</param>
+        /// <param name="array">The array whose slice to fill with bytes read from the stream.</param>
+        /// <param name="offset">
+        /// The first index of the array slice to fill with bytes read from the stream. <c>0</c> starts at the
+        /// beginning of the array.
+        /// </param>
+        /// <param name="length">
+        /// The length of the array slice to fill with bytes read from the stream, or <c>-1</c> to fill the rest of the
+        /// array (starting at <paramref name="offset"/>).
+        /// </param>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the requested array slice could be filled.
+        /// </exception>
+        public static void ReadBytes(this Stream stream, byte[] array, int offset = 0, int length = -1)
+        {
+            if (length == -1)
+            {
+                length = array.Length;
+            }
+
+            int totalRead = 0;
+            while (totalRead < length)
+            {
+                int readNow = stream.Read(array, offset + totalRead, length - totalRead);
+                if (readNow == 0)
+                {
+                    throw new EndOfStreamException();
+                }
+                totalRead += readNow;
+            }
+        }
+
+        /// <summary>
+        /// Reads a single byte from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read a byte.</param>
+        /// <returns>The byte read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">Thrown if the stream ended before a byte could be read.</exception>
+        public static byte ReadByteOrThrow(this Stream stream)
+        {
+            int b = stream.ReadByte();
+            if (b == -1)
+            {
+                throw new EndOfStreamException();
+            }
+            return (byte)b;
+        }
+
+        /// <summary>
+        /// Reads a big-endian unsigned 16-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static ushort ReadBigEndianUInt16(this Stream stream)
+        {
+            var bytes = stream.ReadBytes(2);
+            return (ushort)(
+                ((uint)bytes[0] << 8) |
+                ((uint)bytes[1] << 0)
+            );
+        }
+
+        /// <summary>
+        /// Reads a little-endian unsigned 16-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static ushort ReadLittleEndianUInt16(this Stream stream)
+        {
+            var bytes = stream.ReadBytes(2);
+            return (ushort)(
+                ((uint)bytes[0] << 0) |
+                ((uint)bytes[1] << 8)
+            );
+        }
+
+        /// <summary>
+        /// Reads a big-endian signed 16-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static short ReadBigEndianInt16(this Stream stream)
+        {
+            ushort unsigned = stream.ReadBigEndianUInt16();
+            return unchecked((short)unsigned);
+        }
+
+        /// <summary>
+        /// Reads a little-endian signed 16-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static short ReadLittleEndianInt16(this Stream stream)
+        {
+            ushort unsigned = stream.ReadLittleEndianUInt16();
+            return unchecked((short)unsigned);
+        }
+
+        /// <summary>
+        /// Reads a big-endian unsigned 32-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static uint ReadBigEndianUInt32(this Stream stream)
+        {
+            var bytes = stream.ReadBytes(4);
+            return (
+                ((uint)bytes[0] << 24) |
+                ((uint)bytes[1] << 16) |
+                ((uint)bytes[2] << 8) |
+                ((uint)bytes[3] << 0)
+            );
+        }
+
+        /// <summary>
+        /// Reads a little-endian unsigned 32-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static uint ReadLittleEndianUInt32(this Stream stream)
+        {
+            var bytes = stream.ReadBytes(4);
+            return (
+                ((uint)bytes[0] << 0) |
+                ((uint)bytes[1] << 8) |
+                ((uint)bytes[2] << 16) |
+                ((uint)bytes[3] << 24)
+            );
+        }
+
+        /// <summary>
+        /// Reads a big-endian signed 32-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static int ReadBigEndianInt32(this Stream stream)
+        {
+            uint unsigned = stream.ReadBigEndianUInt32();
+            return unchecked((int)unsigned);
+        }
+
+        /// <summary>
+        /// Reads a little-endian signed 32-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static int ReadLittleEndianInt32(this Stream stream)
+        {
+            uint unsigned = stream.ReadLittleEndianUInt32();
+            return unchecked((int)unsigned);
+        }
+
+        /// <summary>
+        /// Reads a big-endian unsigned 64-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static ulong ReadBigEndianUInt64(this Stream stream)
+        {
+            var bytes = stream.ReadBytes(8);
+            return (
+                ((ulong)bytes[0] << 56) |
+                ((ulong)bytes[1] << 48) |
+                ((ulong)bytes[2] << 40) |
+                ((ulong)bytes[3] << 32) |
+                ((ulong)bytes[4] << 24) |
+                ((ulong)bytes[5] << 16) |
+                ((ulong)bytes[6] << 8) |
+                ((ulong)bytes[7] << 0)
+            );
+        }
+
+        /// <summary>
+        /// Reads a little-endian unsigned 64-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static ulong ReadLittleEndianUInt64(this Stream stream)
+        {
+            var bytes = stream.ReadBytes(8);
+            return (
+                ((ulong)bytes[0] << 0) |
+                ((ulong)bytes[1] << 8) |
+                ((ulong)bytes[2] << 16) |
+                ((ulong)bytes[3] << 24) |
+                ((ulong)bytes[4] << 32) |
+                ((ulong)bytes[5] << 40) |
+                ((ulong)bytes[6] << 48) |
+                ((ulong)bytes[7] << 56)
+            );
+        }
+
+        /// <summary>
+        /// Reads a big-endian signed 64-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static long ReadBigEndianInt64(this Stream stream)
+        {
+            ulong unsigned = stream.ReadBigEndianUInt64();
+            return unchecked((long)unsigned);
+        }
+
+        /// <summary>
+        /// Reads a little-endian signed 64-bit integer from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the integer.</param>
+        /// <returns>The integer read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the integer could be read.
+        /// </exception>
+        public static long ReadLittleEndianInt64(this Stream stream)
+        {
+            ulong unsigned = stream.ReadLittleEndianUInt64();
+            return unchecked((long)unsigned);
+        }
+
+        /// <summary>
+        /// Reads a US-ASCII string of a specific length from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the string.</param>
+        /// <param name="byteCount">The number of characters (bytes) of the US-ASCII string.</param>
+        /// <returns>The string read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the string could be read.
+        /// </exception>
+        public static string ReadUsAsciiString(this Stream stream, int byteCount)
+        {
+            var bytes = stream.ReadBytes(byteCount);
+
+            if (bytes.Any(b => b > 0x7F))
+            {
+                byte firstInvalidByte = bytes.First(b => b > 0x7F);
+                throw new DecoderFallbackException($"invalid US-ASCII byte value {(int)firstInvalidByte}");
+            }
+
+            var chars = bytes
+                .Select(c => (char)c)
+                .ToArray();
+
+            return new string(chars);
+        }
+
+        /// <summary>
+        /// Reads a Windows-1252 string of a specific length from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the string.</param>
+        /// <param name="byteCount">The number of characters (bytes) of the Windows-1252 string.</param>
+        /// <returns>The string read from the stream.</returns>
+        /// <exception cref="EndOfStreamException">
+        /// Thrown if the stream ended before the string could be read.
+        /// </exception>
+        public static string ReadWindows1252String(this Stream stream, int byteCount)
+        {
+            var bytes = stream.ReadBytes(byteCount);
+            var coding = Encoding.GetEncoding("windows-1252");
+            return coding.GetString(bytes, 0, bytes.Length);
+        }
+
+        /// <summary>
+        /// Reads a US-ASCII Pascal string of a specific length from the stream and ensures that an even number of
+        /// bytes have been read.
+        /// </summary>
+        /// <remarks>
+        /// A Pascal string is a sequence of characters prefixed with a byte signifying the length of the string. If
+        /// the length of the string is even,  i.e. the length of the data consisting of length and string is odd, an
+        /// additional byte is read and discarded.
+        /// </remarks>
+        /// <param name="stream">The stream from which to read the string.</param>
+        /// <returns>The US-ASCII string read from the stream.</returns>
+        public static string ReadUsAsciiPascalStringPaddedToEven(this Stream stream)
+        {
+            // get length (1 byte)
+            byte length = stream.ReadByteOrThrow();
+
+            // read that many bytes
+            string str = stream.ReadUsAsciiString(length);
+
+            // if the length is even, then length + string is an odd number of bytes, so skip one more byte
+            if (length % 2 == 0)
+            {
+                int paddingByte = stream.ReadByte();
+                if (paddingByte == -1)
+                {
+                    throw new EndOfStreamException();
+                }
+            }
+
+            return str;
+        }
+
+        /// <summary>
+        /// Reads a Unicode string, as specified by the Photoshop file format documentation, from the stream.
+        /// </summary>
+        /// <remarks>
+        /// A Unicode string, as specified by the Photoshop file format documentation, is a four-byte big-endian
+        /// integer specifying the length of the string in UTF-16 encoding units, followed by that number of big-endian
+        /// 16-bit integers representing the UTF-16-encoded string.
+        /// </remarks>
+        /// <param name="stream">The stream from which to read the string.</param>
+        /// <returns>The string read from the stream.</returns>
+        public static string ReadUnicodeString(this Stream stream)
+        {
+            int length = stream.ReadBigEndianInt32();
+            char[] chars = new char[length];
+
+            for (int i = 0; i < length; ++i)
+            {
+                chars[i] = (char)stream.ReadBigEndianUInt16();
+            }
+
+            return new string(chars);
+        }
+
+        /// <summary>
+        /// Read a big-endian IEEE 754 binary32 floating-point number from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the floating-point number.</param>
+        /// <returns>The floating-point number read from the stream.</returns>
+        public static float ReadBigEndianSingle(this Stream stream)
+        {
+            uint bytesAsInteger = stream.ReadBigEndianUInt32();
+            byte[] bytesAsArray = BitConverter.GetBytes(bytesAsInteger);
+            return BitConverter.ToSingle(bytesAsArray, 0);
+        }
+
+        /// <summary>
+        /// Read a little-endian IEEE 754 binary32 floating-point number from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the floating-point number.</param>
+        /// <returns>The floating-point number read from the stream.</returns>
+        public static float ReadLittleEndianSingle(this Stream stream)
+        {
+            uint bytesAsInteger = stream.ReadLittleEndianUInt32();
+            byte[] bytesAsArray = BitConverter.GetBytes(bytesAsInteger);
+            return BitConverter.ToSingle(bytesAsArray, 0);
+        }
+
+        /// <summary>
+        /// Read a big-endian IEEE 754 binary64 floating-point number from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the floating-point number.</param>
+        /// <returns>The floating-point number read from the stream.</returns>
+        public static double ReadBigEndianDouble(this Stream stream)
+        {
+            ulong bytesAsInteger = stream.ReadBigEndianUInt64();
+            byte[] bytesAsArray = BitConverter.GetBytes(bytesAsInteger);
+            return BitConverter.ToDouble(bytesAsArray, 0);
+        }
+
+        /// <summary>
+        /// Read a little-endian IEEE 754 binary64 floating-point number from the stream.
+        /// </summary>
+        /// <param name="stream">The stream from which to read the floating-point number.</param>
+        /// <returns>The floating-point number read from the stream.</returns>
+        public static double ReadLittleEndianDouble(this Stream stream)
+        {
+            ulong bytesAsInteger = stream.ReadLittleEndianUInt64();
+            byte[] bytesAsArray = BitConverter.GetBytes(bytesAsInteger);
+            return BitConverter.ToDouble(bytesAsArray, 0);
+        }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/ColorMode.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/ColorMode.cs
@@ -1,0 +1,65 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    /// <summary>
+    /// Image Color Mode
+    /// </summary>
+    public enum ColorMode : short
+    {
+        /// <summary>
+        /// A bitmap image (0 or 1 for each pixel).
+        /// </summary>
+        Bitmap = 0,
+
+        /// <summary>
+        /// A grayscale image.
+        /// </summary>
+        Grayscale = 1,
+
+        /// <summary>
+        /// An index image (color palette and indices).
+        /// </summary>
+        Indexed = 2,
+
+        /// <summary>
+        /// An RGB image (red, green and blue components).
+        /// </summary>
+        RGB = 3,
+
+        /// <summary>
+        /// A CMYK image (cyan, magenta, yellow and black components).
+        /// </summary>
+        CMYK = 4,
+
+        /// <summary>
+        /// An image with a custom number of channels.
+        /// </summary>
+        Multichannel = 7,
+
+        /// <summary>
+        /// An image with two components (often black and a spot color).
+        /// </summary>
+        Duotone = 8,
+
+        /// <summary>
+        /// An image in the CIE Lab color space.
+        /// </summary>
+        Lab = 9
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/ColorMode.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/ColorMode.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     /// <summary>
     /// Image Color Mode

--- a/ArtArea/ArtArea.Parsing/Psd/CompressionType.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/CompressionType.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     /// <summary>
     /// The compression type of image data.

--- a/ArtArea/ArtArea.Parsing/Psd/CompressionType.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/CompressionType.cs
@@ -1,0 +1,45 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    /// <summary>
+    /// The compression type of image data.
+    /// </summary>
+    public enum CompressionType : short
+    {
+        /// <summary>
+        /// Raw, uncompressed data.
+        /// </summary>
+        RawData = 0,
+
+        /// <summary>
+        /// Data compressed using the lossless PackBits run-length encoding scheme.
+        /// </summary>
+        PackBits = 1,
+
+        /// <summary>
+        /// Data compressed using the Deflate algorithm.
+        /// </summary>
+        ZipWithoutPrediction = 2,
+
+        /// <summary>
+        /// Data compressed using the Deflate algorithm applied to a per-row delta-encoded version of the data.
+        /// </summary>
+        ZipWithPrediction = 3
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/LayerMaskKind.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/LayerMaskKind.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     /// <summary>
     /// The kind of layer mask. Almost universally <see cref="UsePerLayerValue"/>.

--- a/ArtArea/ArtArea.Parsing/Psd/LayerMaskKind.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/LayerMaskKind.cs
@@ -1,0 +1,40 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    /// <summary>
+    /// The kind of layer mask. Almost universally <see cref="UsePerLayerValue"/>.
+    /// </summary>
+    public enum LayerMaskKind : byte
+    {
+        /// <summary>
+        /// Color selected, i.e. inverted.
+        /// </summary>
+        ColorSelected = 0,
+
+        /// <summary>
+        /// Color protected.
+        /// </summary>
+        ColorProtected = 1,
+
+        /// <summary>
+        /// Use the values stored with each layer.
+        /// </summary>
+        UsePerLayerValue = 128
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDAdditionalLayerInformation.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDAdditionalLayerInformation.cs
@@ -1,0 +1,25 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    public class PSDAdditionalLayerInformation
+    {
+        public string Key { get; set; }
+        public byte[] Data { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDAdditionalLayerInformation.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDAdditionalLayerInformation.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     public class PSDAdditionalLayerInformation
     {

--- a/ArtArea/ArtArea.Parsing/Psd/PSDAdditionalLayerInformation.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDAdditionalLayerInformation.cs
@@ -17,7 +17,7 @@
 
 namespace ArtArea.Parse.Psd
 {
-    public class PSDAdditionalLayerInformation
+    public class PsdAdditionalLayerInformation
     {
         public string Key { get; set; }
         public byte[] Data { get; set; }

--- a/ArtArea/ArtArea.Parsing/Psd/PSDGlobalLayerMask.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDGlobalLayerMask.cs
@@ -17,7 +17,7 @@
 
 namespace ArtArea.Parse.Psd
 {
-    public class PSDGlobalLayerMask
+    public class PsdGlobalLayerMask
     {
         public short OverlayColorSpace { get; set; }
         public short ColorComponent1 { get; set; }

--- a/ArtArea/ArtArea.Parsing/Psd/PSDGlobalLayerMask.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDGlobalLayerMask.cs
@@ -1,0 +1,30 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    public class PSDGlobalLayerMask
+    {
+        public short OverlayColorSpace { get; set; }
+        public short ColorComponent1 { get; set; }
+        public short ColorComponent2 { get; set; }
+        public short ColorComponent3 { get; set; }
+        public short ColorComponent4 { get; set; }
+        public short Opacity { get; set; }
+        public LayerMaskKind Kind { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDGlobalLayerMask.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDGlobalLayerMask.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     public class PSDGlobalLayerMask
     {

--- a/ArtArea/ArtArea.Parsing/Psd/PSDImageDataPlaceholder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDImageDataPlaceholder.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     public class PSDImageDataPlaceholder
     {

--- a/ArtArea/ArtArea.Parsing/Psd/PSDImageDataPlaceholder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDImageDataPlaceholder.cs
@@ -1,0 +1,32 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    public class PSDImageDataPlaceholder
+    {
+        /// <summary>
+        /// The method used to compress the precomposed image data.
+        /// </summary>
+        public CompressionType Compression { get; set; }
+
+        /// <summary>
+        /// The byte position in the PSD file at which the precomposed image data starts.
+        /// </summary>
+        public long Offset { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDImageDataPlaceholder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDImageDataPlaceholder.cs
@@ -17,7 +17,7 @@
 
 namespace ArtArea.Parse.Psd
 {
-    public class PSDImageDataPlaceholder
+    public class PsdImageDataPlaceholder
     {
         /// <summary>
         /// The method used to compress the precomposed image data.

--- a/ArtArea/ArtArea.Parsing/Psd/PSDImageResource.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDImageResource.cs
@@ -1,0 +1,42 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    public class PSDImageResource
+    {
+        /// <summary>
+        /// Identifier for image resources. Any other value should be treated as error
+        /// </summary>
+        internal const string Signature = "8BIM";
+
+        /// <summary>
+        /// The ID of the image resource.
+        /// </summary>
+        public short ID { get; set; }
+
+        /// <summary>
+        /// The name of the image resource. Very often an empty string.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The data of the image resource.
+        /// </summary>
+        public byte[] Data { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDImageResource.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDImageResource.cs
@@ -17,7 +17,7 @@
 
 namespace ArtArea.Parse.Psd
 {
-    public class PSDImageResource
+    public class PsdImageResource
     {
         /// <summary>
         /// Identifier for image resources. Any other value should be treated as error

--- a/ArtArea/ArtArea.Parsing/Psd/PSDImageResource.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDImageResource.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     public class PSDImageResource
     {

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayer.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayer.cs
@@ -17,7 +17,7 @@
 
 using System.Collections.Generic;
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     public class PSDLayer
     {

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayer.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayer.cs
@@ -1,0 +1,108 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace ArtArea.Parsing.Psd
+{
+    public class PSDLayer
+    {
+        /// <summary>
+        /// The top offset in pixels, as a difference between the top edge of the layer and the top edge of the image.
+        /// </summary>
+        public int Top { get; set; }
+
+        /// <summary>
+        /// The left offset in pixels, as a difference between the left edge of the layer and the left edge of the
+        /// image.
+        /// </summary>
+        public int Left { get; set; }
+
+        /// <summary>
+        /// The bottom offset in pixels, as a difference between the bottom edge of the layer and the bottom edge of
+        /// the image.
+        /// </summary>
+        public int Bottom { get; set; }
+
+        /// <summary>
+        /// The right offset in pixels, as a difference between the right edge of the layer and the right edge of the
+        /// image.
+        /// </summary>
+        public int Right { get; set; }
+
+        /// <summary>
+        /// The constituent channels of this layer.
+        /// </summary>
+        public PSDLayerChannel[] Channels { get; set; }
+
+        /// <summary>
+        /// Specifies how this layer is to be combined with the layer below it.
+        /// </summary>
+        public BlendMode BlendMode { get; set; }
+
+        /// <summary>
+        /// The opacity of this layer, a value between 0 (fully transparent) and 255 (fully opaque).
+        /// </summary>
+        public byte Opacity { get; set; }
+
+        /// <summary>
+        /// Whether this layer has non-base clipping.
+        /// </summary>
+        public bool NonBaseClipping { get; set; }
+
+        /// <summary>
+        /// Whether the transparency in this layer is protected.
+        /// </summary>
+        public bool TransparencyProtected { get; set; }
+
+        /// <summary>
+        /// Whether the layer is currently visible.
+        /// </summary>
+        public bool Visible { get; set; }
+
+        public bool Obsolete { get; set; }
+
+        /// <summary>
+        /// Whether the pixel data stored in this layer is irrelevant to the appearance of the document.
+        /// </summary>
+        public bool PixelDataIrrelevantToDocumentAppearance { get; set; }
+
+        /// <summary>
+        /// Information about the mask applied to this layer.
+        /// </summary>
+        public PSDLayerMask LayerMask { get; set; }
+
+        /// <summary>
+        /// The blending ranges of this layer.
+        /// </summary>
+        public PSDLayerBlendingRange[] BlendingRanges { get; set; }
+
+        /// <summary>
+        /// The name of this layer.
+        /// </summary>
+        /// <remarks>
+        /// It is undefined which encoding is used to store the layer name; the Unicode layer name should be extracted
+        /// from the additional layer information instead.
+        /// </remarks>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Additional information about the layer.
+        /// </summary>
+        public List<PSDAdditionalLayerInformation> AdditionalInformation { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayer.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayer.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace ArtArea.Parse.Psd
 {
-    public class PSDLayer
+    public class PsdLayer
     {
         /// <summary>
         /// The top offset in pixels, as a difference between the top edge of the layer and the top edge of the image.
@@ -47,7 +47,7 @@ namespace ArtArea.Parse.Psd
         /// <summary>
         /// The constituent channels of this layer.
         /// </summary>
-        public PSDLayerChannel[] Channels { get; set; }
+        public PsdLayerChannel[] Channels { get; set; }
 
         /// <summary>
         /// Specifies how this layer is to be combined with the layer below it.
@@ -84,12 +84,12 @@ namespace ArtArea.Parse.Psd
         /// <summary>
         /// Information about the mask applied to this layer.
         /// </summary>
-        public PSDLayerMask LayerMask { get; set; }
+        public PsdLayerMask LayerMask { get; set; }
 
         /// <summary>
         /// The blending ranges of this layer.
         /// </summary>
-        public PSDLayerBlendingRange[] BlendingRanges { get; set; }
+        public PsdLayerBlendingRange[] BlendingRanges { get; set; }
 
         /// <summary>
         /// The name of this layer.
@@ -103,6 +103,6 @@ namespace ArtArea.Parse.Psd
         /// <summary>
         /// Additional information about the layer.
         /// </summary>
-        public List<PSDAdditionalLayerInformation> AdditionalInformation { get; set; }
+        public List<PsdAdditionalLayerInformation> AdditionalInformation { get; set; }
     }
 }

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerBlendingRange.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerBlendingRange.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     public struct PSDLayerBlendingRange
     {

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerBlendingRange.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerBlendingRange.cs
@@ -17,7 +17,7 @@
 
 namespace ArtArea.Parse.Psd
 {
-    public struct PSDLayerBlendingRange
+    public struct PsdLayerBlendingRange
     {
         public byte SourceLowFirst { get; set; }
         public byte SourceLowSecond { get; set; }

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerBlendingRange.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerBlendingRange.cs
@@ -1,0 +1,31 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    public struct PSDLayerBlendingRange
+    {
+        public byte SourceLowFirst { get; set; }
+        public byte SourceLowSecond { get; set; }
+        public byte SourceHighFirst { get; set; }
+        public byte SourceHighSecond { get; set; }
+        public byte DestinationLowFirst { get; set; }
+        public byte DestinationLowSecond { get; set; }
+        public byte DestinationHighFirst { get; set; }
+        public byte DestinationHighSecond { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannel.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannel.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     /// <summary>
     /// A constituent channel of a layer in a PSD file.

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannel.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannel.cs
@@ -20,7 +20,7 @@ namespace ArtArea.Parse.Psd
     /// <summary>
     /// A constituent channel of a layer in a PSD file.
     /// </summary>
-    public class PSDLayerChannel
+    public class PsdLayerChannel
     {
         /// <summary>
         /// The ID of this channel.
@@ -29,13 +29,13 @@ namespace ArtArea.Parse.Psd
 
         /// <summary>
         /// The length of the data of the channel. This property is only a mule; the value is eventually stored in
-        /// <see cref="PSDLayerChannelDataPlaceholder.DataLength"/> in <see cref="Data"/>.
+        /// <see cref="PsdLayerChannelDataPlaceholder.DataLength"/> in <see cref="Data"/>.
         /// </summary>
         internal long DataLength { get; set; }
 
         /// <summary>
         /// A placeholder for the data of this channel.
         /// </summary>
-        public PSDLayerChannelDataPlaceholder Data { get; set; }
+        public PsdLayerChannelDataPlaceholder Data { get; set; }
     }
 }

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannel.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannel.cs
@@ -1,0 +1,41 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    /// <summary>
+    /// A constituent channel of a layer in a PSD file.
+    /// </summary>
+    public class PSDLayerChannel
+    {
+        /// <summary>
+        /// The ID of this channel.
+        /// </summary>
+        public short ID { get; set; }
+
+        /// <summary>
+        /// The length of the data of the channel. This property is only a mule; the value is eventually stored in
+        /// <see cref="PSDLayerChannelDataPlaceholder.DataLength"/> in <see cref="Data"/>.
+        /// </summary>
+        internal long DataLength { get; set; }
+
+        /// <summary>
+        /// A placeholder for the data of this channel.
+        /// </summary>
+        public PSDLayerChannelDataPlaceholder Data { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannelDataPlaceholder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannelDataPlaceholder.cs
@@ -1,0 +1,37 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    public class PSDLayerChannelDataPlaceholder
+    {
+        /// <summary>
+        /// The method used to compress the layer data.
+        /// </summary>
+        public CompressionType Compression { get; set; }
+
+        /// <summary>
+        /// The byte position in the PSD file at which the layer data starts.
+        /// </summary>
+        public long Offset { get; set; }
+
+        /// <summary>
+        /// The length of the layer data, as it appears in the PSD file (after compression, if any).
+        /// </summary>
+        public long DataLength { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannelDataPlaceholder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannelDataPlaceholder.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     public class PSDLayerChannelDataPlaceholder
     {

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannelDataPlaceholder.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerChannelDataPlaceholder.cs
@@ -17,7 +17,7 @@
 
 namespace ArtArea.Parse.Psd
 {
-    public class PSDLayerChannelDataPlaceholder
+    public class PsdLayerChannelDataPlaceholder
     {
         /// <summary>
         /// The method used to compress the layer data.

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerMask.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerMask.cs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     public class PSDLayerMask
     {

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerMask.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerMask.cs
@@ -17,7 +17,7 @@
 
 namespace ArtArea.Parse.Psd
 {
-    public class PSDLayerMask
+    public class PsdLayerMask
     {
         /// <summary>
         /// The top offset in pixels, as a difference between the top edge of the layer and the top edge of the image.

--- a/ArtArea/ArtArea.Parsing/Psd/PSDLayerMask.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PSDLayerMask.cs
@@ -1,0 +1,90 @@
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
+
+namespace ArtArea.Parsing.Psd
+{
+    public class PSDLayerMask
+    {
+        /// <summary>
+        /// The top offset in pixels, as a difference between the top edge of the layer and the top edge of the image.
+        /// </summary>
+        public int Top { get; set; }
+
+        /// <summary>
+        /// The left offset in pixels, as a difference between the left edge of the layer and the left edge of the
+        /// image.
+        /// </summary>
+        public int Left { get; set; }
+
+        /// <summary>
+        /// The bottom offset in pixels, as a difference between the bottom edge of the layer and the bottom edge of
+        /// the image.
+        /// </summary>
+        public int Bottom { get; set; }
+
+        /// <summary>
+        /// The right offset in pixels, as a difference between the right edge of the layer and the right edge of the
+        /// image.
+        /// </summary>
+        public int Right { get; set; }
+
+        /// <summary>
+        /// The default color of the layer mask, either 0 or 255.
+        /// </summary>
+        public byte DefaultColor { get; set; }
+
+        /// <summary>
+        /// Whether the position of the mask is relative to the position of the layer.
+        /// </summary>
+        public bool PositionIsRelativeToLayerData { get; set; }
+
+        /// <summary>
+        /// Whether the layer mask is currently disabled.
+        /// </summary>
+        public bool Disabled { get; set; }
+
+        /// <summary>
+        /// Whether to invert the mask when blending. Should be <c>false</c> in most newer PSD files.
+        /// </summary>
+        public bool InvertMaskWhenBlending { get; set; }
+
+        /// <summary>
+        /// Whether the user mask actually originates from rendering other data.
+        /// </summary>
+        public bool OriginatesFromRenderingOtherData { get; set; }
+
+        /// <summary>
+        /// The density of the user mask, or <c>null</c> if not specified.
+        /// </summary>
+        public byte? UserMaskDensity { get; set; }
+
+        /// <summary>
+        /// The feather of the user mask, or <c>null</c> if not specified.
+        /// </summary>
+        public double? UserMaskFeather { get; set; }
+
+        /// <summary>
+        /// The density of the vector mask, or <c>null</c> if not specified.
+        /// </summary>
+        public byte? VectorMaskDensity { get; set; }
+
+        /// <summary>
+        /// The feather of the vector mask, or <c>null</c> if not specified.
+        /// </summary>
+        public double? VectorMaskFeather { get; set; }
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PhotoshopFile.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PhotoshopFile.cs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
+
 namespace ArtArea.Parsing.Psd
 {
     /// <summary>
@@ -29,11 +31,35 @@ namespace ArtArea.Parsing.Psd
     /// </para>
     /// <seealso cref="PsdParser"/>
     /// </summary>
-    public class PsdFile
+    public class PhotoshopFile
     {
+        #region File Format Constants
+
+        /// <summary>
+        /// The minimum number of channels a PSD file must contain.
+        /// </summary>
+        public const short MinChannels = 1;
+
+        /// <summary>
+        /// The maximum number of channels a PSD file can contain.
+        /// </summary>
+        public const short MaxChannels = 56;
+
+        /// <summary>
+        /// The maximum value supported by PSD version 1 for image width and height.
+        /// </summary>
+        public const int PsdMaxDimention = 30000;
+
+        /// <summary>
+        /// The maximum value supported by PSD version 2 for image width and height.
+        /// </summary>
+        public const int PsbMaxDemension = 300000;
+
+        #endregion
+
         #region Header Data Section
 
-        // The file header contains the basic properties of the image.
+        /// The file header contains the basic properties of the image.
 
         /// <summary>
         /// 1 - for .psd, 2 - for .psb (big file format which causes some field size doubling
@@ -83,17 +109,17 @@ namespace ArtArea.Parsing.Psd
 
         #region Color Mode Data Section
 
-        //  Only indexed color and duotone(see the mode field in the File header section) have color 
-        //  mode data.For all other modes, this section is just the 4-byte length field, which is 
-        //  set to zero.
-        //
-        //  Indexed color images: length is 768; color data contains the color table for the image, 
-        //  in non-interleaved order.
-        //
-        //  Duotone images: color data contains the duotone specification (the format of which is 
-        //  not documented). Other applications that read Photoshop files can treat a duotone image 
-        //  as a gray image, and just preserve the contents of the duotone information when reading 
-        //  and writing the file.
+        ///  Only indexed color and duotone(see the mode field in the File header section) have color 
+        ///  mode data.For all other modes, this section is just the 4-byte length field, which is 
+        ///  set to zero.
+        ///
+        ///  Indexed color images: length is 768; color data contains the color table for the image, 
+        ///  in non-interleaved order.
+        ///
+        ///  Duotone images: color data contains the duotone specification (the format of which is 
+        ///  not documented). Other applications that read Photoshop files can treat a duotone image 
+        ///  as a gray image, and just preserve the contents of the duotone information when reading 
+        ///  and writing the file.
 
         /// <summary>
         /// Contains 0 if there is no color data, for Indexed color images contains 768, for Duotone 
@@ -114,6 +140,29 @@ namespace ArtArea.Parsing.Psd
 
         #region Image Resources Section
 
+        /// Image resource blocks are the basic building unit of several file formats, including 
+        /// Photoshop's native file format, JPEG, and TIFF. Image resources are used to store 
+        /// non-pixel data associated with images, such as pen tool paths.
+        ///
+        /// They are referred to as resource blocks because they hold data that was stored in the 
+        /// Macintosh's resource fork in early versions of Photoshop.
+        ///
+        /// The basic structure of image resource blocks is shown in the Image resource block. 
+        /// The last field is the data area, which varies by resource type.The makeup of each 
+        /// resource type is described in the following sections.
+
+
+        /// <summary>
+        /// Length of image resource section. The length may be zero.
+        /// <para>Length: 4 bytes</para>
+        /// </summary>
+        public int ImageRecourceLength { get; set; }
+
+        /// <summary>
+        /// Image resources of the PSD file, primarily metadata.
+        /// <para>Length: variable</para>
+        /// </summary>
+        public List<PSDImageResource> ImageResources { get; set; }
         #endregion
 
         #region Layer and Mask Information Section

--- a/ArtArea/ArtArea.Parsing/Psd/PhotoshopFile.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PhotoshopFile.cs
@@ -17,7 +17,7 @@
 
 using System.Collections.Generic;
 
-namespace ArtArea.Parsing.Psd
+namespace ArtArea.Parse.Psd
 {
     /// <summary>
     /// Represents am Adobe Photoshop .psd file that stores only non-constant data

--- a/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ArtArea.Parsing.Psd
+{
+    /// <summary>
+    /// Represents am Adobe Photoshop .psd file that stores only non-constant data
+    /// which will be enough for rebuilding .psd file from it and also finding 
+    /// difference (delta) between 2 .psd files
+    /// <para>
+    ///     For .psd file structure see 
+    ///     <see href="https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/">
+    ///         Adobe Photoshop File Formats Specification
+    ///     </see>
+    /// </para>
+    /// <seealso cref="PsdParser"/>
+    /// </summary>
+    public class PsdFile
+    {
+        #region Header Data Section
+
+        // The file header contains the basic properties of the image.
+
+        /// <summary>
+        /// Supported range [1, 56]
+        /// <para>Length: 2 bytes</para>
+        /// </summary>
+        public byte NumberOfChannels { get; set; }
+        /// <summary>
+        /// The width of the image in pixels. Supported range is 1 to 30000
+        /// <para>Length: 4 bytes</para>
+        /// </summary>
+        public short Width { get; set; }
+        /// <summary>
+        /// The height of the image in pixels. Supported range is 1 to 30000
+        /// <para>Length: 4 bytes</para>
+        /// </summary>
+        public short Height { get; set; }
+        /// <summary>
+        /// The number of bits per channel. Supported values are 1, 8, 16 and 32
+        /// <para>Length: 2 bytes</para>
+        /// </summary>
+        public byte Depth { get;set; }
+        /// <summary>
+        /// The color mode of the file. Supported values are: 
+        ///     Bitmap = 0; 
+        ///     Grayscale = 1; 
+        ///     Indexed = 2; 
+        ///     RGB = 3; 
+        ///     CMYK = 4; 
+        ///     Multichannel = 7; 
+        ///     Duotone = 8; 
+        ///     Lab = 9
+        /// <para>Length: 2 bytes</para>
+        /// </summary>
+        public byte ColorMode { get; set; }
+
+        #endregion
+
+        #region Color Mode Data Section
+
+        //  Only indexed color and duotone(see the mode field in the File header section) have color 
+        //  mode data.For all other modes, this section is just the 4-byte length field, which is 
+        //  set to zero.
+        //
+        //  Indexed color images: length is 768; color data contains the color table for the image, 
+        //  in non-interleaved order.
+        //
+        //  Duotone images: color data contains the duotone specification (the format of which is 
+        //  not documented). Other applications that read Photoshop files can treat a duotone image 
+        //  as a gray image, and just preserve the contents of the duotone information when reading 
+        //  and writing the file.
+
+        /// <summary>
+        /// Contains 0 if there is no color data, for Indexed color images contains 768, for Duotone 
+        /// images length varies
+        /// <para>
+        ///     Length: 4 bytes
+        /// </para>
+        /// </summary>
+        public int ColorDataLength { get; set; }
+        /// <summary>
+        /// Not empty only for images with indexed or Duotone color mode
+        /// </summary>
+        public byte[] ColorData { get; set; }
+
+        #endregion
+
+        #region Image Resources Section
+
+        #endregion
+
+        #region Layer and Mask Information Section
+
+        #endregion
+
+        #region Image Data Section
+
+        #endregion
+    }
+}

--- a/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
@@ -31,7 +31,7 @@ namespace ArtArea.Parse.Psd
     /// </para>
     /// <seealso cref="PsdParser"/>
     /// </summary>
-    public class PhotoshopFile
+    public class PsdFile
     {
         #region File Format Constants
 
@@ -162,7 +162,7 @@ namespace ArtArea.Parse.Psd
         /// Image resources of the PSD file, primarily metadata.
         /// <para>Length: variable</para>
         /// </summary>
-        public List<PSDImageResource> ImageResources { get; set; }
+        public List<PsdImageResource> ImageResources { get; set; }
         #endregion
 
         #region Layer and Mask Information Section
@@ -196,19 +196,19 @@ namespace ArtArea.Parse.Psd
         /// layer; in this case, the image data is stored in <see cref="PrecomposedImageData"/>.
         /// <para>Length : variable</para>
         /// </summary>
-        public PSDLayer[] Layers { get; set; }
+        public PsdLayer[] Layers { get; set; }
 
         /// <summary>
         /// Information about the global layer mask, or <c>null</c> if the image has no global layer mask.
         /// <para>Length : variable</para>
         /// </summary>
-        public PSDGlobalLayerMask GlobalLayerMask { get; set; }
+        public PsdGlobalLayerMask GlobalLayerMask { get; set; }
 
         /// <summary>
         /// Additional layer information, pertaining the precomposed image layer.
         /// <para>Length : variable</para>
         /// </summary>
-        public List<PSDAdditionalLayerInformation> AdditionalLayerInformation { get; set; }
+        public List<PsdAdditionalLayerInformation> AdditionalLayerInformation { get; set; }
 
         #endregion
 
@@ -240,7 +240,7 @@ namespace ArtArea.Parse.Psd
         /// can be obtained from <see cref="VersionInfo.HasValidPrecomposedData"/>.
         /// <para>Length : variable</para>
         /// </summary>
-        public PSDImageDataPlaceholder PrecomposedImageData { get; set; }
+        public PsdImageDataPlaceholder PrecomposedImageData { get; set; }
 
         #endregion
     }

--- a/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
@@ -128,13 +128,13 @@ namespace ArtArea.Parse.Psd
         ///     Length: 4 bytes
         /// </para>
         /// </summary>
-        public int ColorDataLength { get; set; }
+        public int ColorModeDataLength { get; set; }
 
         /// <summary>
         /// Not empty only for images with <see cref="ColorMode.Indexed"/> or 
         /// <see cref="ColorMode.Duotone"/> color mode
         /// </summary>
-        public byte[] ColorData { get; set; }
+        public byte[] ColorModeData { get; set; }
 
         #endregion
 

--- a/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
@@ -1,6 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// LICENSE NOTICE
+//
+// This file is part of Art Area.
+// 
+// Art Area is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Art Area is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with Art Area.  If not, see<https://www.gnu.org/licenses/>.
 
 namespace ArtArea.Parsing.Psd
 {
@@ -23,25 +36,35 @@ namespace ArtArea.Parsing.Psd
         // The file header contains the basic properties of the image.
 
         /// <summary>
+        /// 1 - for .psd, 2 - for .psb (big file format which causes some field size doubling
+        /// <para>Length: 2 bytes</para>
+        /// </summary>
+        public short Version { get; set; }
+
+        /// <summary>
         /// Supported range [1, 56]
         /// <para>Length: 2 bytes</para>
         /// </summary>
-        public byte NumberOfChannels { get; set; }
+        public short NumberOfChannels { get; set; }
+
         /// <summary>
         /// The width of the image in pixels. Supported range is 1 to 30000
         /// <para>Length: 4 bytes</para>
         /// </summary>
-        public short Width { get; set; }
+        public int Width { get; set; }
+
         /// <summary>
         /// The height of the image in pixels. Supported range is 1 to 30000
         /// <para>Length: 4 bytes</para>
         /// </summary>
-        public short Height { get; set; }
+        public int Height { get; set; }
+
         /// <summary>
         /// The number of bits per channel. Supported values are 1, 8, 16 and 32
         /// <para>Length: 2 bytes</para>
         /// </summary>
-        public byte Depth { get;set; }
+        public short Depth { get;set; }
+
         /// <summary>
         /// The color mode of the file. Supported values are: 
         ///     Bitmap = 0; 
@@ -80,6 +103,7 @@ namespace ArtArea.Parsing.Psd
         /// </para>
         /// </summary>
         public int ColorDataLength { get; set; }
+
         /// <summary>
         /// Not empty only for images with indexed or Duotone color mode
         /// </summary>

--- a/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
+++ b/ArtArea/ArtArea.Parsing/Psd/PsdFile.cs
@@ -77,7 +77,7 @@ namespace ArtArea.Parsing.Psd
         ///     Lab = 9
         /// <para>Length: 2 bytes</para>
         /// </summary>
-        public byte ColorMode { get; set; }
+        public ColorMode ColorMode { get; set; }
 
         #endregion
 
@@ -105,7 +105,8 @@ namespace ArtArea.Parsing.Psd
         public int ColorDataLength { get; set; }
 
         /// <summary>
-        /// Not empty only for images with indexed or Duotone color mode
+        /// Not empty only for images with <see cref="ColorMode.Indexed"/> or 
+        /// <see cref="ColorMode.Duotone"/> color mode
         /// </summary>
         public byte[] ColorData { get; set; }
 

--- a/ArtArea/ArtArea.sln
+++ b/ArtArea/ArtArea.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArtArea.Parsing", "ArtArea.Parsing\ArtArea.Parsing.csproj", "{39F7F543-8C7B-490B-9651-A064FB5BE3E4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{39F7F543-8C7B-490B-9651-A064FB5BE3E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39F7F543-8C7B-490B-9651-A064FB5BE3E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39F7F543-8C7B-490B-9651-A064FB5BE3E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39F7F543-8C7B-490B-9651-A064FB5BE3E4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A8F9F1CC-4420-46C4-8C6C-0BDCBC80D5D4}
+	EndGlobalSection
+EndGlobal

--- a/ArtArea/ArtArea.sln
+++ b/ArtArea/ArtArea.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArtArea.Parsing", "ArtArea.Parsing\ArtArea.Parsing.csproj", "{39F7F543-8C7B-490B-9651-A064FB5BE3E4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArtArea.Parse", "ArtArea.Parsing\ArtArea.Parse.csproj", "{39F7F543-8C7B-490B-9651-A064FB5BE3E4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/psd-test-file-description.md
+++ b/psd-test-file-description.md
@@ -1,6 +1,6 @@
 # Description for .psd files used for testing
 
-[**Download files**]()
+[**Download files**](https://drive.google.com/file/d/1dt4qlkiyT5oUKGm5DBfYVcxXGDnZ-dt4/view?usp=sharing)
 
 By default files are placed into `\ArtArea\TestSourceFiles\`
 

--- a/psd-test-file-description.md
+++ b/psd-test-file-description.md
@@ -1,0 +1,47 @@
+# Description for .psd files used for testing
+
+[**Download files**]()
+
+By default files are placed into `\ArtArea\TestSourceFiles\`
+
+## How to undestand file default settings?
+
+For quicker testing names of files cosist of key parameters (devided by `-`) used for building them:
+
+`file_name-width-height-resolution-resolution_type-color_mode-depth-white?`
+
+- `file_name` represents what is in file (if it is empty, than file name is so)
+- `width` & `height` obviously represent file width & height
+- `resolution` is number (by default it is 300)
+- `resultion_type` is number 
+  - 1 => Pixels/Inch
+  - 2 => Pixels/Centimeter 
+- `color_mode` is used color mode
+        
+  My Photoshop version supports only 
+  - 1 => *Bitmap*
+  - 2 => *Grayscale* 
+  - 3 => *RGB Color* 
+  - 4 => *CMYK Color* 
+  - 5 => *Lab Color*
+
+- `depth` is amount of bits for color mode option
+  - 1 => 8 bit
+  - 2 => 16 bit
+  - 3 => 32 bit
+
+- `white?` takes 1 for true & 0 for false, which means that this file was basically with white or transparent background 
+
+Defaults:
+- Color Profile : Working RGB: sRGB IEC61966-2.1
+- Pixel Aspect Ration : Square Pixels
+
+## File list
+
+- `empty-512-512-300-1-3-1-1` : empty file
+- `irden-512-512-300-1-3-1-1` : irden sign from Witcher 3 game
+- `dots-512-512-300-1-3-1-1` : some randomly place round dots
+
+---
+
+**Add more files** :rocket:


### PR DESCRIPTION
## Change Log
- Add class that represents `.psd` or `.psb` file format
- Add builder (reader) for class that represents Photoshop file
  
## Change Description
Added console project (.NET Core 3) which will be rebuild as library for further usage

## To-Do Changes
Waiting for @mohorka to commit her changes for reading 
- [ ] _Layer & Mask Info_
- [ ] _Image Data Placeholder_

## Related Issues
#4 (Photoshop File Parsing & Analysis)

## Materials and useful links
Based on [RavuAlHemio/PSD](https://github.com/RavuAlHemio/PSD) project (a bit rewritten & retargeted for modern .NET Core version - initial project uses .NET Core 1.1)